### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-draganything"
+description = "DragAnything"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["accelerate>=0.25.0", "certifi>=2023.11.17", "charset-normalizer>=3.3.2", "cmake>=3.28.1", "contourpy>=1.1.1", "cycler>=0.12.1", "decord>=0.6.0", "diffusers==0.19.3", "docopt>=0.6.2", "einops>=0.7.0", "ffmpeg>=1.4", "filelock>=3.13.1", "fonttools>=4.47.2", "fsspec>=2023.12.2", "huggingface-hub>=0.20.1", "idna>=3.6", "imageio>=2.33.1", "importlib-metadata>=7.0.1", "importlib-resources>=6.1.1", "Jinja2>=3.1.2", "kiwisolver>=1.4.5", "lit>=17.0.6", "MarkupSafe>=2.1.3", "matplotlib>=3.7.4", "mpmath>=1.3.0", "mypy-extensions>=1.0.0", "networkx>=3.1", "numpy>=1.24.4", "opencv-python>=4.8.1.78", "packaging>=23.2", "Pillow>=10.1.0", "pipreqs>=0.4.13", "psutil>=5.9.7", "pyparsing>=3.1.1", "pyre-extensions>=0.0.29", "python-dateutil>=2.8.2", "PyYAML>=6.0.1", "regex>=2023.12.25", "requests>=2.31.0", "safetensors>=0.4.1", "scipy>=1.10.1", "segment-anything>=1.0", "six>=1.16.0", "sympy>=1.12", "tokenizers>=0.15.0", "tqdm>=4.66.1", "transformers>=4.36.2", "typing-inspect>=0.9.0", "typing_extensions>=4.9.0", "urllib3>=2.1.0", "yarg>=0.1.9", "zipp>=3.17.0"]
+
+[project.urls]
+Repository = "https://github.com/chaojie/ComfyUI-DragAnything"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-DragAnything"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!